### PR TITLE
--generator=run-pod/v1 parameter added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,12 @@ RUN apt-get update \
     swaks \
     telnet \
     vim \
+    nano \
     wget \
     influxdb-client \
     rabbitmq-server
 
-RUN curl -O https://raw.githubusercontent.com/rabbitmq/rabbitmq-management/v3.7.8/bin/rabbitmqadmin \
+RUN curl -O https://raw.githubusercontent.com/rabbitmq/rabbitmq-management/v3.7.14/bin/rabbitmqadmin \
   && mv rabbitmqadmin /usr/local/bin/ \
   && chmod +x /usr/local/bin/rabbitmqadmin
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ When using containers you might want to test the connectivity between the contai
 For example, to run a one-off container in Kubernetes:
 
 ```
-kubectl run --rm utils -it --image arunvelsriram/utils bash
+kubectl run --rm utils -it --generator=run-pod/v1 --image arunvelsriram/utils bash
 
 # You will be seeing a bash prompt
 $ psql -h hostname -U test -d test
@@ -18,7 +18,7 @@ $ psql -h hostname -U test -d test
 $ exit
 ```
 
-**Note:** `--rm` option will delete the `deployment` and related `pod` after exiting from the container. Skip `--rm` to preserve the `deployment` and related `pod` so that you can exec in to the `pod` and test your application any time.
+**Note:** `--rm` option will delete the  `pod` after exiting from the container
 
 ## General Usage
 


### PR DESCRIPTION
kubectrl run for the deployment is deprecated.
```kubectl run --rm utils -it --image arunvelsriram/utils bash
kubectl run --generator=deployment/apps.v1 is DEPRECATED and will be removed in a future version. Use kubectl run --generator=run-pod/v1 or kubectl create instead.```