### PR TITLE
Adding hey for http benchmarking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,4 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 RUN curl -O https://storage.googleapis.com/hey-release/hey_linux_amd64 \
   && mv hey_linux_amd64 /usr/local/bin/hey \
-  && chmod +x /usr/local/bin/hey \
-  && cp /usr/local/bin/hey /usr/local/bin/ab
+  && chmod +x /usr/local/bin/hey

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,3 +36,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+RUN curl -O https://storage.googleapis.com/hey-release/hey_linux_amd64 \
+  && mv hey_linux_amd64 /usr/local/bin/hey \
+  && chmod +x /usr/local/bin/hey \
+  && cp /usr/local/bin/hey /usr/local/bin/ab

--- a/test/test.bats
+++ b/test/test.bats
@@ -116,3 +116,9 @@ load test_helper
 	run check_cmd "ssh"
 	[ "$status" -eq 0 ]
 }
+@test "hey" {
+	run check_cmd "hey"
+	[ "$status" -eq 0 ]
+	run check_cmd "ab"
+	[ "$status" -eq 0 ]
+}

--- a/test/test.bats
+++ b/test/test.bats
@@ -119,6 +119,4 @@ load test_helper
 @test "hey" {
 	run check_cmd "hey"
 	[ "$status" -eq 0 ]
-	run check_cmd "ab"
-	[ "$status" -eq 0 ]
 }


### PR DESCRIPTION
hey (https://github.com/rakyll/hey) is the ab (https://en.wikipedia.org/wiki/ApacheBench) replacement.
1. Have symlinked to /usr/bin/ab as well for ppl who are used to typing ab
2. Not sure if the `bats` test should be like this for symlink.