### PR TITLE
fix env syntax error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,9 +69,9 @@ RUN curl -s https://raw.githubusercontent.com/birdayz/kaf/master/godownloader.sh
 
 # Locale setup
 RUN locale-gen en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US:en
-ENV LC_ALL=en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # Unprivileged user setup
 RUN groupadd --gid ${UTILS_USER_GID} utils \


### PR DESCRIPTION
fix the previous 3 warning messages

```
3 warnings found (use --debug to expand):

LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 73)
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 74)
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 75)
```